### PR TITLE
remove forge conditional recipe type

### DIFF
--- a/src/main/resources/data/geolosys/recipes/blasting/aluminum_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/aluminum_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:aluminum_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:aluminum_cluster"
-        },
-        "result": "geolosys:aluminum_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:aluminum_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:aluminum_cluster"
+  },
+  "result": "geolosys:aluminum_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/copper_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/copper_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:copper_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:copper_cluster"
-        },
-        "result": "minecraft:copper_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:copper_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:copper_cluster"
+  },
+  "result": "minecraft:copper_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/gold_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/gold_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:gold_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:gold_cluster"
-        },
-        "result": "minecraft:gold_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:gold_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:gold_cluster"
+  },
+  "result": "minecraft:gold_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/iron_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/iron_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:iron_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:iron_cluster"
-        },
-        "result": "minecraft:iron_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:iron_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:iron_cluster"
+  },
+  "result": "minecraft:iron_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/lead_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/lead_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:lead_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:lead_cluster"
-        },
-        "result": "geolosys:lead_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:lead_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:lead_cluster"
+  },
+  "result": "geolosys:lead_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/netherite_scrap_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/netherite_scrap_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:netherite_scrap",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:ancient_debris_cluster"
-        },
-        "result": "minecraft:netherite_scrap",
-        "experience": 1.0,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:netherite_scrap"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:ancient_debris_cluster"
+  },
+  "result": "minecraft:netherite_scrap",
+  "experience": 1.0,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/nickel_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/nickel_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:nickel_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:nickel_cluster"
-        },
-        "result": "geolosys:nickel_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:nickel_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:nickel_cluster"
+  },
+  "result": "geolosys:nickel_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/platinum_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/platinum_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:platinum_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:platinum_cluster"
-        },
-        "result": "geolosys:platinum_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:platinum_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:platinum_cluster"
+  },
+  "result": "geolosys:platinum_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/silver_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/silver_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:silver_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:silver_cluster"
-        },
-        "result": "geolosys:silver_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:silver_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:silver_cluster"
+  },
+  "result": "geolosys:silver_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/tin_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/tin_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:tin_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:tin_cluster"
-        },
-        "result": "geolosys:tin_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:tin_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:tin_cluster"
+  },
+  "result": "geolosys:tin_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/blasting/zinc_ingot_from_cluster_blasting.json
+++ b/src/main/resources/data/geolosys/recipes/blasting/zinc_ingot_from_cluster_blasting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:blasting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:zinc_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:blasting",
-        "ingredient": {
-          "item": "geolosys:zinc_cluster"
-        },
-        "result": "geolosys:zinc_ingot",
-        "experience": 0.7,
-        "cookingtime": 100
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:zinc_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:zinc_cluster"
+  },
+  "result": "geolosys:zinc_ingot",
+  "experience": 0.7,
+  "cookingtime": 100
 }

--- a/src/main/resources/data/geolosys/recipes/compat/immersiveengineering/bituminous_coke_from_coke_oven.json
+++ b/src/main/resources/data/geolosys/recipes/compat/immersiveengineering/bituminous_coke_from_coke_oven.json
@@ -1,29 +1,17 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "immersiveengineering:coke_oven",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "type": "forge:mod_loaded",
-              "modid": "immersiveengineering"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "immersiveengineering:coke_oven",
-        "result": {
-          "item": "geolosys:bituminous_coal_coke"
-        },
-        "input": {
-          "item": "geolosys:bituminous_coal"
-        },
-        "creosote": 750,
-        "time": 1500
-      }
+      "type": "forge:mod_loaded",
+      "modid": "immersiveengineering"
     }
-  ]
+  ],
+  "result": {
+    "item": "geolosys:bituminous_coal_coke"
+  },
+  "input": {
+    "item": "geolosys:bituminous_coal"
+  },
+  "creosote": 750,
+  "time": 1500
 }

--- a/src/main/resources/data/geolosys/recipes/compat/immersiveengineering/lignite_coke_from_coke_oven.json
+++ b/src/main/resources/data/geolosys/recipes/compat/immersiveengineering/lignite_coke_from_coke_oven.json
@@ -1,29 +1,17 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "immersiveengineering:coke_oven",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "type": "forge:mod_loaded",
-              "modid": "immersiveengineering"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "immersiveengineering:coke_oven",
-        "result": {
-          "item": "geolosys:lignite_coal_coke"
-        },
-        "input": {
-          "item": "geolosys:lignite_coal"
-        },
-        "creosote": 750,
-        "time": 1500
-      }
+      "type": "forge:mod_loaded",
+      "modid": "immersiveengineering"
     }
-  ]
+  ],
+  "result": {
+    "item": "geolosys:lignite_coal_coke"
+  },
+  "input": {
+    "item": "geolosys:lignite_coal"
+  },
+  "creosote": 750,
+  "time": 1500
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/aluminum_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/aluminum_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:aluminum_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:aluminum_cluster"
-        },
-        "result": "geolosys:aluminum_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:aluminum_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:aluminum_cluster"
+  },
+  "result": "geolosys:aluminum_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/copper_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/copper_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:copper_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:copper_cluster"
-        },
-        "result": "minecraft:copper_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:copper_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:copper_cluster"
+  },
+  "result": "minecraft:copper_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/gold_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/gold_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:gold_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:gold_cluster"
-        },
-        "result": "minecraft:gold_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:gold_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:gold_cluster"
+  },
+  "result": "minecraft:gold_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/iron_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/iron_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:iron_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:iron_cluster"
-        },
-        "result": "minecraft:iron_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:iron_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:iron_cluster"
+  },
+  "result": "minecraft:iron_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/lead_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/lead_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:lead_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:lead_cluster"
-        },
-        "result": "geolosys:lead_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:lead_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:lead_cluster"
+  },
+  "result": "geolosys:lead_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/netherite_scrap_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/netherite_scrap_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "minecraft:netherite_scrap",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:ancient_debris_cluster"
-        },
-        "result": "minecraft:netherite_scrap",
-        "experience": 1.0,
-        "cookingtime": 400
-      }
+      "type": "forge:item_exists",
+      "item": "minecraft:netherite_scrap"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:ancient_debris_cluster"
+  },
+  "result": "minecraft:netherite_scrap",
+  "experience": 1.0,
+  "cookingtime": 400
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/nickel_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/nickel_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:nickel_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:nickel_cluster"
-        },
-        "result": "geolosys:nickel_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:nickel_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:nickel_cluster"
+  },
+  "result": "geolosys:nickel_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/platinum_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/platinum_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:platinum_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:platinum_cluster"
-        },
-        "result": "geolosys:platinum_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:platinum_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:platinum_cluster"
+  },
+  "result": "geolosys:platinum_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/silver_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/silver_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:silver_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:silver_cluster"
-        },
-        "result": "geolosys:silver_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:silver_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:silver_cluster"
+  },
+  "result": "geolosys:silver_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/tin_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/tin_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:tin_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:tin_cluster"
-        },
-        "result": "geolosys:tin_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:tin_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:tin_cluster"
+  },
+  "result": "geolosys:tin_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/geolosys/recipes/smelting/zinc_ingot_from_cluster_smelting.json
+++ b/src/main/resources/data/geolosys/recipes/smelting/zinc_ingot_from_cluster_smelting.json
@@ -1,27 +1,15 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "minecraft:smelting",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "values": [
-            {
-              "item": "geolosys:zinc_ingot",
-              "type": "forge:item_exists"
-            }
-          ],
-          "type": "forge:and"
-        }
-      ],
-      "recipe": {
-        "type": "minecraft:smelting",
-        "ingredient": {
-          "item": "geolosys:zinc_cluster"
-        },
-        "result": "geolosys:zinc_ingot",
-        "experience": 0.7,
-        "cookingtime": 200
-      }
+      "type": "forge:item_exists",
+      "item": "geolosys:zinc_ingot"
     }
-  ]
+  ],
+  "ingredient": {
+    "item": "geolosys:zinc_cluster"
+  },
+  "result": "geolosys:zinc_ingot",
+  "experience": 0.7,
+  "cookingtime": 200
 }

--- a/src/main/resources/data/immersiveengineering/recipes/blastfurnace/bituminous_coal_coke.json
+++ b/src/main/resources/data/immersiveengineering/recipes/blastfurnace/bituminous_coal_coke.json
@@ -1,18 +1,11 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "immersiveengineering:blast_furnace_fuel",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "type": "forge:mod_loaded",
-          "modid": "immersiveengineering"
-        }
-      ],
-      "recipe": {
-        "type": "immersiveengineering:blast_furnace_fuel",
-        "input": { "item": "geolosys:bituminous_coal_coke" },
-        "time": 2400
-      }
+      "type": "forge:mod_loaded",
+      "modid": "immersiveengineering"
     }
-  ]
+  ],
+  "input": { "item": "geolosys:bituminous_coal_coke" },
+  "time": 2400
 }

--- a/src/main/resources/data/immersiveengineering/recipes/blastfurnace/lignite_coal_coke.json
+++ b/src/main/resources/data/immersiveengineering/recipes/blastfurnace/lignite_coal_coke.json
@@ -1,18 +1,11 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "immersiveengineering:blast_furnace_fuel",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "type": "forge:mod_loaded",
-          "modid": "immersiveengineering"
-        }
-      ],
-      "recipe": {
-        "type": "immersiveengineering:blast_furnace_fuel",
-        "input": { "item": "geolosys:lignite_coal_coke" },
-        "time": 1800
-      }
+      "type": "forge:mod_loaded",
+      "modid": "immersiveengineering"
     }
-  ]
+  ],
+  "input": { "item": "geolosys:lignite_coal_coke" },
+  "time": 1800
 }

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/coke_dust_from_bituminous_coal_coke.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/coke_dust_from_bituminous_coal_coke.json
@@ -1,20 +1,13 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "immersiveengineering:crusher",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "type": "forge:mod_loaded",
-          "modid": "immersiveengineering"
-        }
-      ],
-      "recipe": {
-        "type": "immersiveengineering:crusher",
-        "input": { "item": "geolosys:bituminous_coal_coke" },
-        "secondaries": [],
-        "result": { "tag": "forge:dusts/coal_coke" },
-        "energy": 3600
-      }
+      "type": "forge:mod_loaded",
+      "modid": "immersiveengineering"
     }
-  ]
+  ],
+  "input": { "item": "geolosys:bituminous_coal_coke" },
+  "secondaries": [],
+  "result": { "tag": "forge:dusts/coal_coke" },
+  "energy": 3600
 }

--- a/src/main/resources/data/immersiveengineering/recipes/crusher/coke_dust_from_lignite_coal_coke.json
+++ b/src/main/resources/data/immersiveengineering/recipes/crusher/coke_dust_from_lignite_coal_coke.json
@@ -1,20 +1,13 @@
 {
-  "type": "forge:conditional",
-  "recipes": [
+  "type": "immersiveengineering:crusher",
+  "conditions": [
     {
-      "conditions": [
-        {
-          "type": "forge:mod_loaded",
-          "modid": "immersiveengineering"
-        }
-      ],
-      "recipe": {
-        "type": "immersiveengineering:crusher",
-        "input": { "item": "geolosys:lignite_coal_coke" },
-        "secondaries": [],
-        "result": { "tag": "forge:dusts/coal_coke" },
-        "energy": 3600
-      }
+      "type": "forge:mod_loaded",
+      "modid": "immersiveengineering"
     }
-  ]
+  ],
+  "input": { "item": "geolosys:lignite_coal_coke" },
+  "secondaries": [],
+  "result": { "tag": "forge:dusts/coal_coke" },
+  "energy": 3600
 }


### PR DESCRIPTION
The forge conditional recipe type is a pain to work with when writing mods that integrate with other mods or JSON recipes.

Since you don't define multiple recipes inside a JSON file, there is no need to use this recipe type. Instead, you can use the `conditions` property inside a recipe JSON.

I tested the new recipes with and without Immersive Engineering. No errors and no warnings about the recipes and they still load fine when IE is loaded.
Please consider merging this and use the same format for future recipes as this make cross mod compatibility a lot easier.